### PR TITLE
Update pyzx version to 0.8

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* Updated pyzx version requirement to 0.8.0.
+
 0.31.0 (January 2024)
 ---------------------
 

--- a/pytket/extensions/pyzx/pyzx_convert.py
+++ b/pytket/extensions/pyzx/pyzx_convert.py
@@ -16,26 +16,25 @@
 
 from typing import Dict, Tuple
 from fractions import Fraction
-import pyzx as zx  # type: ignore
-from pyzx.circuit import Circuit as pyzxCircuit  # type: ignore
-from pyzx.routing.architecture import Architecture as PyzxArc  # type: ignore
-from pyzx.graph.graph import Graph as PyzxGraph  # type: ignore
+from pyzx.circuit import Circuit as pyzxCircuit, gates as zxGates
+from pyzx.routing.architecture import Architecture as PyzxArc
+from pyzx.graph.graph import Graph as PyzxGraph
 from pytket.circuit import OpType, Circuit, Op, Qubit, UnitID
 from pytket.architecture import Architecture
 
 _tk_to_pyzx_gates = {
-    OpType.Rz: zx.gates.ZPhase,
-    OpType.Rx: zx.gates.XPhase,
-    OpType.X: zx.gates.NOT,
-    OpType.Z: zx.gates.Z,
-    OpType.S: zx.gates.S,  # gate.adjoint == False
-    OpType.Sdg: zx.gates.S,  # gate.adjoint == True
-    OpType.T: zx.gates.T,  # gate.adjoint == False
-    OpType.Tdg: zx.gates.T,  # gate.adjoint == True
-    OpType.CX: zx.gates.CNOT,
-    OpType.CZ: zx.gates.CZ,
-    OpType.H: zx.gates.HAD,
-    OpType.SWAP: zx.gates.SWAP,
+    OpType.Rz: zxGates.ZPhase,
+    OpType.Rx: zxGates.XPhase,
+    OpType.X: zxGates.NOT,
+    OpType.Z: zxGates.Z,
+    OpType.S: zxGates.S,  # gate.adjoint == False
+    OpType.Sdg: zxGates.S,  # gate.adjoint == True
+    OpType.T: zxGates.T,  # gate.adjoint == False
+    OpType.Tdg: zxGates.T,  # gate.adjoint == True
+    OpType.CX: zxGates.CNOT,
+    OpType.CZ: zxGates.CZ,
+    OpType.H: zxGates.HAD,
+    OpType.SWAP: zxGates.SWAP,
 }
 
 _pyzx_to_tk_gates: Dict = dict(
@@ -74,11 +73,11 @@ def tk_to_pyzx(tkcircuit: Circuit, denominator_limit: int = 1000000) -> pyzxCirc
         gate_class = _tk_to_pyzx_gates[op.type]
         adjoint = op.type == OpType.Sdg or op.type == OpType.Tdg
         qbs = [q.index[0] for q in command.args]
-        gate = 0  # assignment
+        gate: zxGates.Gate  # assignment
         n_params = len(op.params)
         if n_params == 1:
             phase = op.params[0]
-            if type(phase) != float:
+            if not isinstance(phase, float):
                 raise Exception(
                     "Cannot convert tket gate: "
                     + str(op)
@@ -126,7 +125,11 @@ def pyzx_to_tk(pyzx_circ: pyzxCircuit) -> Circuit:
         elif op_type == OpType.Tdg and not getattr(g, "adjoint"):
             op_type = OpType.T
 
-        if hasattr(g, "print_phase") and op_type in _parameterised_gates:
+        if (
+            hasattr(g, "print_phase")
+            and hasattr(g, "phase")
+            and op_type in _parameterised_gates
+        ):
             op = Op.create(op_type, g.phase)
         else:
             op = Op.create(op_type)

--- a/pytket/extensions/pyzx/pyzx_convert.py
+++ b/pytket/extensions/pyzx/pyzx_convert.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Methods to allow conversion between pyzx and tket data types
-"""
+"""Methods to allow conversion between pyzx and tket data types"""
 
 from typing import Dict, Tuple
 from fractions import Fraction
@@ -127,7 +126,7 @@ def pyzx_to_tk(pyzx_circ: pyzxCircuit) -> Circuit:
         elif op_type == OpType.Tdg and not getattr(g, "adjoint"):
             op_type = OpType.T
 
-        if hasattr(g, "printphase") and op_type in _parameterised_gates:
+        if hasattr(g, "print_phase") and op_type in _parameterised_gates:
             op = Op.create(op_type, g.phase)
         else:
             op = Op.create(op_type)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 1.24", "pyzx ~= 0.7.0"],
+    install_requires=["pytket ~= 1.24", "pyzx ~= 0.8.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
# Description

Updates the `pyzx` dependency to `v0.8.0`.

https://github.com/Quantomatic/pyzx/pull/136 renamed the gate attribute `printphase` to `print_phase`, which caused our tests to fail.

# Related issues

Closes #55 

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
