### PR TITLE
chore: Fix new ruff lints

### DIFF
--- a/pytket/extensions/pyzx/pyzx_convert.py
+++ b/pytket/extensions/pyzx/pyzx_convert.py
@@ -16,6 +16,7 @@ from fractions import Fraction
 
 from pytket.architecture import Architecture
 from pytket.circuit import Circuit, Op, OpType, Qubit, UnitID
+
 from pyzx.circuit import Circuit as pyzxCircuit
 from pyzx.circuit import gates as zxGates
 from pyzx.graph.graph import Graph as PyzxGraph

--- a/tests/pyzx_convert_test.py
+++ b/tests/pyzx_convert_test.py
@@ -14,9 +14,11 @@
 
 import numpy as np
 import pytest
-
 from pytket.architecture import Architecture
 from pytket.circuit import Circuit, fresh_symbol
+from pytket.passes import AASRouting, CXMappingPass
+from pytket.placement import GraphPlacement
+
 from pytket.extensions.pyzx import (
     pyzx_to_tk,
     pyzx_to_tk_arc,
@@ -25,8 +27,6 @@ from pytket.extensions.pyzx import (
     tk_to_pyzx_arc,
     tk_to_pyzx_placed_circ,
 )
-from pytket.passes import AASRouting, CXMappingPass
-from pytket.placement import GraphPlacement
 
 
 @pytest.mark.filterwarnings("ignore:strict=False")


### PR DESCRIPTION
Fixes the new ruff lints warnings that are preventing us from merging other PRs.

See https://github.com/CQCL/pytket-pyzx/actions/runs/18825668460/job/53707865071?pr=91#step:6:13

```py
I001 [*] Import block is un-sorted or un-formatted
  --> pytket/extensions/pyzx/pyzx_convert.py:15:1
   |
13 |   # limitations under the License.
14 |
15 | / from fractions import Fraction
16 | |
17 | | from pytket.architecture import Architecture
18 | | from pytket.circuit import Circuit, Op, OpType, Qubit, UnitID
19 | | from pyzx.circuit import Circuit as pyzxCircuit
20 | | from pyzx.circuit import gates as zxGates
21 | | from pyzx.graph.graph import Graph as PyzxGraph
22 | | from pyzx.routing.architecture import Architecture as PyzxArc
   | |_____________________________________________________________^
23 |
24 |   _tk_to_pyzx_gates = {
   |
help: Organize imports
```